### PR TITLE
add error for no roll args

### DIFF
--- a/src/bin/roll.rs
+++ b/src/bin/roll.rs
@@ -16,6 +16,11 @@ fn run(args: Vec<String>) -> Result<(), String> {
         return Ok(());
     }
 
+    // check for no arguments
+    if matches.free.len() == 1 {
+        return Err("missing dice".to_string());
+    }
+
     // convert args to a Vec<DiceToRoll>
     let mut dice: Vec<DiceToRoll> = Vec::new();
     for roll in matches.free.iter().skip(1) {


### PR DESCRIPTION
Add an error for no roll args.
The user is prompted to use 'roll --help'.
closes #24
